### PR TITLE
Adding 3rd Eclipse Ditto GitHub repository

### DIFF
--- a/conf/projects.json
+++ b/conf/projects.json
@@ -256,10 +256,12 @@
     "iot.ditto": {
       "git": [
         "https://github.com/eclipse/ditto --labels=[application]",
+        "https://github.com/eclipse/ditto-clients --labels=[application]",
         "https://github.com/eclipse/ditto-examples --labels=[application]"
       ],
       "github": [
         "https://github.com/eclipse/ditto --labels=[application]",
+        "https://github.com/eclipse/ditto-clients --labels=[application]",
         "https://github.com/eclipse/ditto-examples --labels=[application]"
       ],
       "meta": { "title" : "Eclipse" }


### PR DESCRIPTION
"ditto-clients" contains Java and JavaScript SDKs for accessing Eclipse Ditto.